### PR TITLE
More snippets, compile before testing, syntax edits

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -91,15 +91,49 @@
     }, 
     "Print Message": {
         "prefix": ["print "],
-        "body": ["print ${1:_expression_}"],
+        "body": ["print ${1:_message_};"],
         "description": ["Print Statement: Writes or prints log message into error traces. "]
     }, 
     "Print Formatted Message": {
         "prefix": ["print format(\""],
-        "body": ["print format(${1:_expression_})"],
+        "body": ["print format(${1:_message_});"],
         "description": ["Print Statement: Writes or prints formatted log message into the error traces. "]
+    },
+    "If Statement": {
+        "prefix": ["if ", "if( "],
+        "body": ["if (${1:_condition_})", "{", "\t${2:_statement_};", "}"], 
+        "description": ["If statement: If the conditional is met, the statement is run."]
+    },
+    "If-Else Statement": {
+        "prefix": ["if ", "if( "],
+        "body": ["if (${1:_condition_})", "{", "\t${2:_statement_};", "}", "else", "{","${3:_statement_}", "}"], 
+        "description": ["If-Else statement: If the conditional is met, the statement is run. If it isn't met, the else statement is run."]
+    },
+    "New Statement": {
+        "prefix": ["new "],
+        "body": ["new ${1:_instance_}(${2:_constructorParameters_});"], 
+        "description": ["Creates a dynamic instance of the object and passes the constructor parameters in."]
+    }, 
+    "Announce Statement": {
+        "prefix": ["announce "], 
+        "body": ["announce ${1:_event_}, ${2:_payload_};"],
+        "description": ["Announce Statement: Announces if an event has occured to specification monitors during system execution."]
+    },
+    "Goto Statement": {
+        "prefix": ["goto "],
+        "body": ["goto ${1:_state_};"],
+        "description": ["Goto Statement: Terminates the execution of the current function and enters the target state."]
+    },
+    "Goto Statement with Payload": {
+        "prefix": ["goto "], 
+        "body": ["goto ${1:_state_}, ${2:_payload_};"], 
+        "description": ["Goto Statement: Terminates the execution of the current function and enters the target state with the input parameters."]
+    }, 
+    "Receive Statement": {
+        "prefix": ["receive {"], 
+        "body": ["receive { ", "\tcase ${1:_event_}: {${2:_caseHandler_}}","}"],
+        "description": ["Receive Statement: Blocks await/receive for a set of events inside a function."]
     }
-    
 }
 
 

--- a/src/ui/relatedErrorView.ts
+++ b/src/ui/relatedErrorView.ts
@@ -37,16 +37,16 @@ export default class RelatedErrorView {
         
         context.subscriptions.push(
             //adds errors
-            this.watcherP.onDidChange(async () => await RelatedErrorView.instance.refreshRelatedErrors()),
-            this.watcher_pproj.onDidChange(async () => await RelatedErrorView.instance.refreshRelatedErrors()),
+            this.watcherP.onDidChange(async () => await RelatedErrorView.refreshRelatedErrors()),
+            this.watcher_pproj.onDidChange(async () => await RelatedErrorView.refreshRelatedErrors()),
             RelatedErrorView.instance
         );
-        RelatedErrorView.instance.refreshRelatedErrors();
+        RelatedErrorView.refreshRelatedErrors();
         return RelatedErrorView.instance;
     }
 
 
-    public async refreshRelatedErrors(): Promise<void> {
+    public static async refreshRelatedErrors(): Promise<void> {
       for (var t of await vscode.tasks.fetchTasks()) {
         if (t.name === "Run_Report") {
           var exec: vscode.TaskExecution = await vscode.tasks.executeTask(t);

--- a/src/ui/testinginEditor.ts
+++ b/src/ui/testinginEditor.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { ExtensionConstants, LanguageConstants, TestResults } from '../constants';
+import RelatedErrorView from './relatedErrorView';
 const fs = require('fs');
 
 export default class TestingEditor {
@@ -107,8 +108,11 @@ async function runHandler (request: vscode.TestRunRequest, token: vscode.Cancell
     run.end();
 }
 
+//Compiles the P directory.
 //If the Test Item is a file: run its children. Else: Run the test case.
 async function handlePTestCase(run: vscode.TestRun, tc: vscode.TestItem) {
+    await RelatedErrorView.refreshRelatedErrors();
+
     if (tc.parent == undefined) {
         tc.children.forEach(item => runPTestCase(run, item))
     }
@@ -120,6 +124,7 @@ async function handlePTestCase(run: vscode.TestRun, tc: vscode.TestItem) {
 //Always runs a single P Test Case.
 async function runPTestCase(run: vscode.TestRun, tc: vscode.TestItem) {
     var result = TestResults.Error;
+    
     let terminal = vscode.window.activeTerminal ?? vscode.window.createTerminal();
     if (terminal.name == ExtensionConstants.RunTask) {
         for (let i = 0; i<vscode.window.terminals.length; i++) {

--- a/syntaxes/p.YAML-tmLanguage
+++ b/syntaxes/p.YAML-tmLanguage
@@ -127,6 +127,7 @@ repository:
           name: keyword.control
       end:  \)
       patterns:
+      - include: "#functioncall"
       - include: "#operators"
       - include: "#constants"
       - include: "#strings"

--- a/syntaxes/p.tmLanguage.json
+++ b/syntaxes/p.tmLanguage.json
@@ -220,6 +220,9 @@
           "end": "\\)",
           "patterns": [
             {
+              "include": "#functioncall"
+            },
+            {
               "include": "#operators"
             },
             {


### PR DESCRIPTION
**Preliminary Instructions to Install the Extension**
1. Clone this repository.
2. cd into the repository.
3. Run 'vsce package -o ~ '.
4. The extension should now be in your user directory. Now, open a P code directory and navigate to the command pallete.
5. Search and click onto the command Extensions: Install from VSIX...
<img width="595" alt="Screenshot 2023-07-07 at 12 24 51 PM" src="https://github.com/p-org/peasy-ide-vscode/assets/135176059/8e2ad8a9-82de-498e-b2dc-a05e7c7538cb">

6. Install the VSIX file you just created. 
7. You should get a notification saying **Completed installing P Extension extension from VSIX.**
8. Your extension should now be working!

**Summary**
I added more snippets to the extension, encompassing almost all statement constructs in P. 
I also made some other fixes:

- Right before tests are run through the green arrow in the IDE, the program is compiled again. 
- Fixed syntax issues in the syntax highlighting