### PR TITLE
Support for Testing Multiple Projects and Compiling Multiple P Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Preliminary instructions to install this extension:
 NOTE: Remove any previous versions of the extension from the extensions folder in .vscode. 
 1. Clone this repository.
 2. cd into the repository.
-3. Run 'vsce package -o ~ '. If the command errors, run 'brew install vsce' and re-run the command.
+3. Run 'vsce package -o ~ '. If the command errors, run 'brew install vsce' and re-run the previous command.
 4. The extension should now be in your user directory. Now, open a P code directory and navigate to the command pallete.
 5. Search and click onto the command "Extensions: Install from VSIX..."
 6. Install the VSIX file you just created.
@@ -16,7 +16,7 @@ You should get a notification saying "Completed installing P Extension extension
 Reload VSCode, and your extension should now be working!
 
 Further P Extension Support:
-1. Compilation: Open any P project folder. Navigate to a file that ends with .p or .pproj and press 'f5' to compile. 
+1. Compilation: Open any P project repository. Press 'f5' OR Save any file to compile. If there are multiple P projects, choose which project to compile at the top bar. 
 2. Use P's Custom Theme by selecting with the dropdown at Code > Settings > Theme > Color Theme.
 3. P should now support Errors that occur during compilation in the Problems panel. 
 4. Snippets: Typing out the beginning of P data structures and syntactic structures within a P program, such as "machine", "test", and "foreach" will cause snippets to load that have the general structure loaded as well. Pressing tab will allow the user to 'fill in the blank' of each structure.
@@ -24,11 +24,11 @@ Further P Extension Support:
 
 
 ## Features
-\!\[Error Reporting\]\(images/error_reporting.png\)
-\!\[Snippets\]\(images/snippets.png\)
-\!\[Syntax Highlighting\]\(images/syntax_highlighting_1.png\)
-\!\[Testing Framework\]\(images/testing_framework.png\)
-\!\[Iteration Settings\]\(images/Iteration_Settings.png\)
+![Error Reporting](./images/error_reporting.png)
+![Snippets](./images/snippets.png)
+![Syntax Highlighting](./images/syntax_highlighting_1.png)
+![Testing Framework](./images/testing_framework.png)
+![Iteration Settings](./images/Iteration_Settings.png)
 > Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
 
 ## Requirements

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,5 +26,10 @@
         ["(", ")"],
         ["\"", "\""],
         ["'", "'"]
-    ]
+    ], 
+
+    "indentationRules": {
+        "increaseIndentPattern": "{",
+        "decreaseIndentPattern": ""
+    }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "vscode": "^1.78.0"
   },
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:**/*.p"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/p-org/peasy-ide-vscode.git"
@@ -81,6 +83,11 @@
         "args": "p-vscode: Run_Report",
         "key": "f5", 
         "mac": "f5"
+      }, 
+      {
+        "command": "workbench.files",
+        "key": "f4",
+        "mac": "f4"
       }
     ],
     "configuration": {
@@ -114,6 +121,10 @@
       {
         "command": "workbench.errors",
         "title": "Error"
+      }, 
+      {
+        "command": "workbench.files",
+        "title": "Files"
       }
     ], 
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,14 +1,12 @@
 export namespace PCommands {
-  //Un-used
-    export const RUN = 'p.Run'; 
-  //Used
-    export const DEFINITION = 'p.definition'
-  }
-  
-   export namespace VSCodeCommands {
-     export const OPEN = 'vscode.open';
-     export const SAVEAS = 'workbench.action.files.saveAs';
-     export const CONFIGURE = 'workbench.action.openSettings';
-     export const ERRORS = 'workbench.errors'
-   }
+  export const RunTask = 'Run_Report';
+  export const FilesTask = 'Files';
+}
+
+export namespace VSCodeCommands {
+  export const OPEN = 'vscode.open';
+  export const SAVEAS = 'workbench.action.files.saveAs';
+  export const CONFIGURE = 'workbench.action.openSettings';
+  export const ERRORS = 'workbench.errors'
+}
   

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,6 @@ export namespace LanguageConstants {
   
   export namespace ExtensionConstants {
     export const ChannelName = 'P VSCode';
-    export const RunTask = 'Run_Report';
   }
   
   export namespace ConfigurationConstants {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "Ps Extension" is live!');
+	console.log('Congratulations, your extension "P\'s Extension" is live!');
 
 
 	const statusOutput = window.createOutputChannel(ExtensionConstants.ChannelName);

--- a/src/language/PLanguageClient.ts
+++ b/src/language/PLanguageClient.ts
@@ -1,6 +1,6 @@
 import { Diagnostic, Uri } from 'vscode';
 import { HandleDiagnosticsSignature, LanguageClient, LanguageClientOptions, ServerOptions, TextDocumentPositionParams } from 'vscode-languageclient/node';
-import { PDocumentFilter } from '../tools/vscode';
+import { PDocumentFilter } from '../tools/vscode'
 import { PInstaller } from './PInstallation';
 import Configuration from '../configuration';
 import { ConfigurationConstants,LanguageConstants } from '../constants';

--- a/src/miscTools.ts
+++ b/src/miscTools.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+//Searches the current file directory for a specific pattern string and returns all files that match the pattern
+export async function searchDirectory(pattern: string) {
+    var files = null;
+    if (vscode.workspace.workspaceFolders !== undefined) 
+    {
+        const folder = vscode.workspace.workspaceFolders[0].uri
+        let filePattern: vscode.RelativePattern = new vscode.RelativePattern(folder,pattern )
+        files = await vscode.workspace.findFiles(filePattern)
+    }
+    return files;
+
+}

--- a/src/ui/autoCompletion.ts
+++ b/src/ui/autoCompletion.ts
@@ -1,5 +1,0 @@
-// import * as vscode from vscode;
-// export default class AutoCompletion 
-// {
-
-// }

--- a/src/ui/compileCommands.ts
+++ b/src/ui/compileCommands.ts
@@ -1,41 +1,129 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as messages from './messages';
 
 
-import { PCommands, VSCodeCommands} from '../commands';
 import { ExtensionConstants } from '../constants';
+import { searchDirectory } from '../miscTools';
+import { PCommands } from '../commands';
 
 
-//Class is DEPRECATED right now. Only keeping in case it becomes useful.
 // const OutputPathArg = '--output';
 //This class runs commands in the terminal based on Compile Command (example: F5 = "p compile")
 
 export default class CompileCommands {
-  public static createAndRegister(): CompileCommands {
-    createTask();
+  //Current Command that f5 and save will generate.
+  static command: string = 'p compile';
+  //All the current P Projects
+  static projects: vscode.QuickPickItem[] = [];
+  static options: vscode.QuickPickOptions = {title:"Choose the project to compile...", canPickMany:false, onDidSelectItem:changeCompilationCommand};
+  
+  public static createAndRegister(context:vscode.ExtensionContext): CompileCommands {
+    generateProjects();
+    createCompileTask();
+    vscode.commands.registerCommand('workbench.files', async() => vscode.window.showQuickPick(CompileCommands.projects, this.options))
+
+    context.subscriptions.push(
+      vscode.workspace.onDidDeleteFiles(e => generateProjects()),
+      vscode.workspace.onDidCreateFiles(e => generateProjects())
+    )
 
     return new CompileCommands();
   }
 }
 
+//Change the command WHEN the user selects a different item. 
+async function changeCompilationCommand(item: vscode.QuickPickItem) {
+  CompileCommands.command = "p compile -pp " + item.description;
+}
+
+
 // Runs p compile in the terminal.
-async function createTask() {
-  var type = ExtensionConstants.RunTask;
-  vscode.tasks.registerTaskProvider(type, {
-    provideTasks(token?: vscode.CancellationToken) {
-        var execution = new vscode.ShellExecution("p compile");
-        var problemMatchers = ["$Parse", "$Type"];
-        return [
-            new vscode.Task({type: type}, vscode.TaskScope.Workspace,
-                "Run_Report", "p-vscode", execution, problemMatchers)
-        ];
+async function createCompileTask() {
+  var type = PCommands.RunTask;
+  vscode.tasks.registerTaskProvider(type, 
+  {
+    async provideTasks(token?: vscode.CancellationToken) 
+    {
+      var msg = CompileCommands.command;
+      var execution = new vscode.ShellExecution(msg);
+      var problemMatchers = ["$Parse", "$Type"];
+      return [
+          new vscode.Task({type: type}, vscode.TaskScope.Workspace,
+          "Run_Report", "p-vscode", execution, problemMatchers)
+      ];
     },
     resolveTask(task: vscode.Task, token?: vscode.CancellationToken) {
         return task;
     }
   });
 }
+
+/*
+Choose file to compile.
+Case 1: No pproj file -> Error window
+Case 2: One pproj file -> command: 'p compile' & quick pick shows single line 
+Case 3: Multiple pproj file -> 'p compile -pp ....' & quick pick shows many lines.
+*/
+
+
+
+/*
+This is run WHEN:
+-The extension is first activated. 
+-File Deletion
+-File Creation
+*/ 
+
+//IDEA: only update the files being deleted or created, instead of running this everytime. 
+async function generateProjects() {
+  var files = await searchDirectory("*.pproj");
+  if (files == null) {  //No directory to speak of.
+    vscode.window.showErrorMessage(messages.Messages.CompilationStatus.NoDirectory);
+    return;
+  }
+  else if (files.length == 0) {                 
+    //Top-level of program doesn't have P project files.
+    files = await searchDirectory("**/*.pproj")
+    if (files == null) {
+      vscode.window.showErrorMessage(messages.Messages.CompilationStatus.NoDirectory);
+      return;
+      
+    }
+    else if (files.length == 0) { //No pproj files anywhere in the program.
+      vscode.window.showErrorMessage(messages.Messages.CompilationStatus.NoPprojFile);
+      return;
+    }
+    //We just want to CHECK if the current compile command has been set yet. 
+    else if (files.length == 1 && files.at(0)!=undefined) {
+      var projectName = files.at(0)?.fsPath.split('/').at(-1);
+      CompileCommands.command = "p compile -pp " + files.at(0)?.path;
+      if (projectName != undefined) {
+        CompileCommands.projects = [({label:projectName, description: files.at(0)?.fsPath})]
+      }
+      
+      return;
+    }
+    else {
+      CompileCommands.projects = [];
+      for (var f of files) {
+        //Add all the file pproj files to the options for the user to choose from. 
+        var fileName = f.fsPath.split('/').at(-1);
+        if (fileName != undefined) {
+          var item:vscode.QuickPickItem = {label:fileName, description:f.fsPath};
+          CompileCommands.projects.push(item);
+        }
+      }
+
+      //Set the compile command to the first P project discovered.
+      CompileCommands.command = "p compile -pp " + CompileCommands.projects.at(0)?.description;
+
+    }
+
+  }
+}
+
 
 
 

--- a/src/ui/definitionView.ts
+++ b/src/ui/definitionView.ts
@@ -1,5 +1,0 @@
-// import * as vscode from 'vscode';
-
-// export default class DefinitionView {
-//     public default class 
-// }

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -1,18 +1,8 @@
 export namespace Messages {
     export namespace CompilationStatus {
-      export const Parsing = '$(sync~spin) Parsing...';
-      export const Resolving = '$(sync~spin) Resolving...';
-      export const ParsingFailed = '$(thumbsdown) Parsing Failed';
-      export const ResolutionFailed = '$(thumbsdown) Resolution Failed';
-      export const PreparingVerification = '$(sync~spin) Preparing verification...';
-      export const CompilationSucceeded = '$(book) Resolved (not verified)';
-      export const Verifying = '$(sync~spin) Verifying';
-      export const VerificationSucceeded = '$(thumbsup) Verification Succeeded';
-      export const VerificationFailedOld = '$(thumbsdown) Verification Failed';
-      export const VerificationFailed = '$(thumbsdown) Could not prove';
-  
-      export const Verified = '$(thumbsup) Verified';
-      export const NotVerified = '$(thumbsdown) Not Verified';
+      export const NoPprojFile = "The current directory does not contain ANY local *.pproj folder. Compilation is impossible.";
+      export const MultiplePprofFile = "The current directory contains multiple *.pproj folders. Please select which project to compile.";
+      export const NoDirectory = "The current directory is invalid.";
     }
   
     export namespace Compiler {

--- a/src/ui/pIntegration.ts
+++ b/src/ui/pIntegration.ts
@@ -3,8 +3,8 @@ import CompileCommands from "./compileCommands";
 import RelatedErrorView from "./relatedErrorView";
 import TestingEditor from "./testinginEditor";
 
-export default function createAndRegisterPIntegration(installer: PInstaller): void {
-    CompileCommands.createAndRegister();
+export default async function createAndRegisterPIntegration(installer: PInstaller): Promise<void> {
+    await CompileCommands.createAndRegister(installer.context);
     RelatedErrorView.createAndRegister(installer.context);
     TestingEditor.createAndRegister(installer.context);
 }

--- a/src/ui/relatedErrorView.ts
+++ b/src/ui/relatedErrorView.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { PLanguageClient } from '../language/PLanguageClient';
-import { getVsDocumentPath } from '../tools/vscode';
+
 
 //This class helps create error messages when you hover over error squiggles. 
 
@@ -53,7 +53,6 @@ export default class RelatedErrorView {
 
         }
       }
-      console.log("No Errors Task");
     }
 
     public clearRelatedErrors(documentPath: string): void {

--- a/syntaxes/p.YAML-tmLanguage
+++ b/syntaxes/p.YAML-tmLanguage
@@ -98,18 +98,26 @@ repository:
     - name: keyword.statement.other
       match: \bassert\b|\bprint\b|\bnew\b|\braise\b|\bsend\b|\bannounce\b|\breceive\b|\bgoto\b
   primitive_func:
-    name: primitive_func
-    begin: (sizeof|keys|values|default|choose)
-    beginCaptures: 
-      "1":
-        name: entity.name.function.primitive
-    end: \)
     patterns:
+    - name: primitive_func
+      begin: (sizeof|keys|values|choose)
+      beginCaptures: 
+        "1":
+          name: entity.name.function.primitive
+      end: \)
+      patterns:
       - include: "#operators"
       - include: "#constants"
       - include: "#strings"
       - include: "#expressions"
       - include: "#identifier"
+    - name: default_func 
+      begin: default
+      beginCaptures:
+        "1": 
+          name: entity.name.function.primitive 
+      end: \) 
+      contentName: storage.type.other
   expressions:
     patterns:
     - name: expression.format

--- a/syntaxes/p.tmLanguage.json
+++ b/syntaxes/p.tmLanguage.json
@@ -166,29 +166,44 @@
       ]
     },
     "primitive_func": {
-      "name": "primitive_func",
-      "begin": "(sizeof|keys|values|default|choose)",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.name.function.primitive"
-        }
-      },
-      "end": "\\)",
       "patterns": [
         {
-          "include": "#operators"
+          "name": "primitive_func",
+          "begin": "(sizeof|keys|values|choose)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.primitive"
+            }
+          },
+          "end": "\\)",
+          "patterns": [
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#constants"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#expressions"
+            },
+            {
+              "include": "#identifier"
+            }
+          ]
         },
         {
-          "include": "#constants"
-        },
-        {
-          "include": "#strings"
-        },
-        {
-          "include": "#expressions"
-        },
-        {
-          "include": "#identifier"
+          "name": "default_func",
+          "begin": "default",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.primitive"
+            }
+          },
+          "end": "\\)",
+          "contentName": "storage.type.other"
         }
       ]
     },


### PR DESCRIPTION
**Preliminary Instructions to Install the Extension**
1. Clone this repository.
2. cd into the repository.
3. Run 'vsce package -o ~ '.
4. The extension should now be in your user directory. Now, open a P code directory and navigate to the command pallete.
5. Search and click onto the command Extensions: Install from VSIX...
<img width="595" alt="Screenshot 2023-07-07 at 12 24 51 PM" src="https://github.com/p-org/peasy-ide-vscode/assets/135176059/8e2ad8a9-82de-498e-b2dc-a05e7c7538cb">

6. Install the VSIX file you just created. 
7. You should get a notification saying **Completed installing P Extension extension from VSIX.**
8. Your extension should now be working!

**Summary**
Sometimes P repositories have multiple P Project folders; to account for this, I added a capability to change the folder the user is currently working on. For example, **if an user presses 'f4', a screen pops up at the very top of the VSCode screen that allows the user to select which P folder to compile when they press 'f5' or when they save.** 
![Screenshot 2023-07-12 at 5 12 16 PM](https://github.com/p-org/peasy-ide-vscode/assets/135176059/6af396f8-f941-4080-b971-f2f920fc4da8)
A random P project is automatically compiled if nothing is ever selected, and if there is only one P project, that project will automatically be compiled without a need for user input. 

I also changed the testing capability to allow for multiple testing repositories to exist when there are multiple PTst folders. 
![Screenshot 2023-07-12 at 5 16 10 PM](https://github.com/p-org/peasy-ide-vscode/assets/135176059/cd317da0-0a14-4499-bbc8-dea6c02b915e)
