### PR TITLE
modifying the publish action to not release on every tag.

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,28 @@
+name: Publish vscode extension to VS Marketplace
+
+on:
+  release:
+    types: [published]
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VSCE_PAT }}
+          registryUrl: https://marketplace.visualstudio.com


### PR DESCRIPTION
**Summary of Changes:**

1. Rename file to more suitable name stating what type of action is getting create.
2. Using `release` as the trigger instead of push on `tags` to publish the extension. We would like to control when we want to publish a new version of the extension and may not be needed for every tag. 

A release in GitHub is a higher-level concept built on top of Git tags. When you create a release in GitHub, it creates a Git tag for the commit you're targeting, if it doesn't already exist. In addition to the functionality of tags, releases provide extra features:

- You can provide release notes and documentation alongside your code.
- You can attach binary files (like compiled executables, minified scripts, and other dependencies).
- GitHub creates a zip or tar.gz of your source code to download at the specific tag.