### PR TITLE
Fixed visualizer unable to visualize ClientServer error trace

### DIFF
--- a/src/shivizSourceHtml.ts
+++ b/src/shivizSourceHtml.ts
@@ -559,7 +559,7 @@ const shivizSourceHtml = (
                   <script type="text/javascript" src="${shivizScriptsUriMap["requestResponseFinder"]}"></script>
                   <script type="text/javascript" src="${shivizScriptsUriMap["textQueryMotifFinder"]}"></script>
 
-                  <script type="text/javascript" src="${shivizScriptsUriMap["shiviz"]}" jsonLogs=${errorTraceJsonLogsString}></script>
+                  <script type="text/javascript" src="${shivizScriptsUriMap["shiviz"]}"></script>
 
                   <script type="text/javascript" src="${shivizScriptsUriMap["transformation"]}"></script>
                   <script type="text/javascript" src="${shivizScriptsUriMap["collapseSequentialNodesTransformation"]}"></script>


### PR DESCRIPTION
\+ Remove unused `jsonLogs` input when calling shiviz script in HTML that caused an error
\+ Better workflow warning message on cases when json error trace can't be found