### PR TITLE
Remove digits as delimiter to correctly identify testcase name

### DIFF
--- a/src/ui/testinginEditor.ts
+++ b/src/ui/testinginEditor.ts
@@ -113,7 +113,7 @@ function parsePTestFile(
         new vscode.Position(lineNo, 0),
         new vscode.Position(lineNo, line.length)
       );
-      const words = line.split("test ")[1].split(/ |[^A-Za-z_]/);
+      const words = line.split("test ")[1].split(/ |[^A-Za-z_0-9]/);
       events.onTest(words[0], range);
       continue;
     }


### PR DESCRIPTION
Issue:
If a test case name has numbers (e.g., testBasicPaxos2on3), the executed p check  command is incorrect (should be p check -tc testBasicPaxos2on3  instead of p check -tc testBasicPaxos ), resulting in an unexpected error thrown.

Rootcause:
The delimiters used to split the test file strings to extract testcase names included digits. Because of this, the actual testcase name (Ex: testBasicPaxos2on3) which contained digits was split based on digits (split into ["testBasicPaxos", "on"]) and incorrectly identified (as "testBasicPaxos").

Fix:
Removed digits from the set of delimiters used to split the string.