### PR TITLE
Updates to webpage

### DIFF
--- a/Docs/docs/contribute.md
+++ b/Docs/docs/contribute.md
@@ -7,12 +7,12 @@
 </style>
 
 <div align="center">
-  <h2>Contribute to the Peasy Extension!</h2>
+  <h2>Contribute to Peasy!</h2>
 </div>
 
 If you would like to contribute or add to the current state of the Peasy extension, here are the steps to do so:
 
-1.  **Clone** the [Peasy extension repository](https://github.com/p-org/peasy-ide-vscode).
+1.  **Clone** the [Peasy repository](https://github.com/p-org/peasy-ide-vscode).
 
 2.  **Navigate** into the directory of the extension on your Terminal or on a coding editor. Run the following command on the command line.
 
@@ -22,11 +22,11 @@ If you would like to contribute or add to the current state of the Peasy extensi
 
 3.  **Build** the repository to convert Typescript code into Javascript code.
 
-    !!! note "How to Build the Peasy Extension Repository"
+    !!! note "How to Build Peasy Repository"
 
         * Mac: ++cmd+shift+b++
         * Windows: ++ctrl+shift+b++
 
-4.  In order to test out the extension, press ++f5++ to create an `Extension Development Host` where users can open P projects to view how the extension looks in its current state.
+4.  In order to test out the extension, press ++f5++ to create an `Extension Development Host` where you can open P projects to view how the extension looks in its current state.
 
 ![Extension Dev Host](../images/extension_host.png)

--- a/Docs/docs/features/compilation/basic.md
+++ b/Docs/docs/features/compilation/basic.md
@@ -9,11 +9,9 @@
 <div align="center">
   <h2>Automatic Compilation in Peasy</h2>
 </div>
-Compiling in P is made easy with this addition to our extension!
+Compiling P programs is now super easy with Peasy!
 
-Simple press ++f5++ or `Save` in your VSCode terminal and your project will automatically compile the current P project folder with the `p compile` command.
-
-The Peasy extension also handles cases where there are multiple P project files in the current working directory. Press ++f4++ and a pop-up will appear, displaying all the P projects inside of the folder. Select the project you want to work on at the moment, and that project will compile every time you press ++f5++.
+Simply press ++f5++ or `Save` in VS Code and your project will automatically compile the current P project with the `p compile` command.
 
 <figure class="video_container">
   <video controls="true" allowfullscreen="true" >

--- a/Docs/docs/features/compilation/error_reporting.md
+++ b/Docs/docs/features/compilation/error_reporting.md
@@ -10,9 +10,9 @@
   <h2>Error Reporting in Peasy</h2>
 </div>
 
-The Peasy extension automatically detects errors in P. There are two types of errors in P: Parse Errors and Type Errors.
+Peasy automatically detects compilation errors in your P project. There are two types of compile-time errors in P: Parse Errors and Type Errors.
 
-If compiling a P project with ++f5++ triggers errors, the user may simply open the `Problems` panel in VSCode to view all the errors within their project. Then, users can navigate to the location of the error by simply clicking the error.
+If compiling a P project with ++f5++ triggers errors, you can simply open the `Problems` panel in VS Code to view all compilation errors in the current P project. Then, you can jump to the error location by simply clicking the error.
 
 <figure class="video_container">
   <video controls="true" allowfullscreen="true" >

--- a/Docs/docs/features/compilation/multiple.md
+++ b/Docs/docs/features/compilation/multiple.md
@@ -9,11 +9,11 @@
 <div align="center">
   <h2>Multiple Projects: Automatic Compilation</h2>
 </div>
-When working in a P project directory with a single project, the Peasy extension handles which project is compiled for you!
+When working in a directory with a single P project, Peasy automatically identifies the P project.
 
-**But what if there are multiple projects within a single directory?**
+**But what if there are multiple P projects in the same directory?**
 
-To select another project that compiles after pressing ++f5++ and `Save`, press ++f4++. This will trigger a pop-up that shows all the available P projects available to compile in your current working directory. Simply click or select the project you wish to compile automatically, and change the selected project later as needed!
+To select another P project, press ++f4++. This will trigger a pop-up that shows all the available P projects in your current working directory. Simply click or select one of them to change the current P project!
 
 <figure class="video_container">
   <video controls="true" allowfullscreen="true" >

--- a/Docs/docs/features/snippets.md
+++ b/Docs/docs/features/snippets.md
@@ -10,11 +10,13 @@
   <h2>Snippet Auto-Completion in Peasy</h2>
 </div>
 
-Coding in P became much easier with snippets! Snippets allow P developers to complete templates of repeating code patterns in P, such as state machines, different statements, test cases, and more. Snippets appear through **Intellisense** when users type out the beginning of P keywords such as **machine** or **test** or **send**.
+Coding in P is now much easier with snippets! Snippets allow P developers to complete templates of repeating code patterns in P, such as state machines, P statements, test cases, and more. Snippets appear through **Intellisense** when you type out the beginning of P keywords such as **machine** or **test** or **send**.
 
-After selecting a particular snippet, users can press `Tab` in order to jump to edit each placeholder in the snippet.
+After selecting a particular snippet, press `Tab` in order to jump to edit each placeholder in the snippet.
 
-Snippets help P developers code faster and easier because they don't need to refer back to documentation for help when coding common data structures in P. Below is an example tutorial of coding with snippets in P!
+Snippets help P developers code faster and easier because they don't need to refer back to documentation for help when coding common data structures in P.
+
+Below is an example demo of coding with snippets in P!
 
 <figure class="video_container">
   <video controls="true" allowfullscreen="true" >

--- a/Docs/docs/features/syntax_highlighting.md
+++ b/Docs/docs/features/syntax_highlighting.md
@@ -9,7 +9,9 @@
 <h2>Syntax Highlighting in Peasy</h2>
 </div>
 
-Syntax highlighting in P makes developing programs in P easier, faster, and more enjoyable.
+Syntax highlighting in P makes developing P programs easier, faster, and more enjoyable.
 
-We created a Custom P theme that the P team prefers to develop in P, but feel free to change the theme to whatever you would like!
+We created a Custom P theme that we suggest, but feel free to change the theme to whatever you like!
+
+Here is a sample of syntax highlighting for the [Two Phase Commit](https://github.com/p-org/P/tree/master/Tutorial/2_TwoPhaseCommit) protocol from the P tutorial. 
 ![Syntax Highlighting](../images/syntax_highlighting.png)

--- a/Docs/docs/features/testing.md
+++ b/Docs/docs/features/testing.md
@@ -10,11 +10,12 @@
   <h2>How to Run P Test Cases</h2>
 </div>
 
-Testing in P is made easy with this modification to the Peasy extension!
+Testing P programs is also super easy with Peasy!
 
-Navigate to the Testing Panel in VSCode, and users will find names of P testing folders with P test cases under them. The Testing Panel allows users to easily run test cases from anywhere in a P project directory by clicking the play button.
+Simply click the :material-play-outline: button next to a test case to run it.
 
-Users can also navigate to the testing folders by pressing the icon to the right of the play button. If an user navigates to a testing file, they can also click a green play button to run P test cases there too!
+The Testing Panel in VS Code lists all P test cases.
+In this panel, click the :material-play-outline: button to run test cases or jump to the corresponding test case in the P program by pressing the icon right next to :material-play-outline: button. 
 
 <figure class="video_container">
   <video controls="true" allowfullscreen="true" >

--- a/Docs/docs/features/visualizations.md
+++ b/Docs/docs/features/visualizations.md
@@ -10,17 +10,16 @@
   <h2>Peasy State Machine Visualizations</h2>
 </div>
 
-Many P users wanted a method of creating visualizations of P state machines and their transitions, states, and events to help supplement design documents, visualize P code, and help to better understand the way P state machines worked. With the help of the open source tool Stately's State Machine Visualization, that dream is now realized.
+Many P users wanted a method of creating visualizations of P state machines and their transitions, states, and events to help supplement design documents, visualize P code, and help to better understand the way P state machines worked. With the help of the open-source tool [Stately](https://stately.ai/viz), that dream is now realized.
 
-In order to create visualizations of P state machines, follow these steps or scroll down to watch the tutorial:
+In order to create visualizations of P state machines, follow these steps or scroll down to watch a demo:
 
-1. First, select the P project you want to work with. (If you are already working in a directory with just one P project, then skip this step.) Otherwise, press ++f6++ and select the project you would like to visualize.
-2. Now, press ++f7++ to run the command `p compile --mode stately` in the terminal. Your visualization code is generated! A message in red should be sent through the terminal.
+1. Press ++f7++ to run the command `p compile --mode stately` in the terminal. Your visualization code is generated! A message in red should be sent through the terminal.
    ![Syntax Highlighting](../images/code_generation_text.png)
-3. Navigate to the file using ++ctrl++ `Click` or ++cmd++ `Click`. Copy-and-paste the file contents into https://stately.ai/viz.
-4. Click the Visualize button on the bottom left!
+2. Navigate to the file using ++ctrl++ `Click` or ++cmd++ `Click`. Copy-and-paste the file contents into https://stately.ai/viz.
+3. Click the Visualize button on the bottom left!
 
-Voila! Here is an example visualization using the P Tutorial's Two Phase Commit Project.
+Voila! Here is an example visualization using the P Tutorial's Two Phase Commit project.
 ![Visualization](../images/visualization.png)
 
 <div align="center">
@@ -33,14 +32,14 @@ States are represented with squares, and events are represented with ovals.The b
 
 The state WaitForTransaction is outlined in blue because the machine always travelled from the `Init` State to the WaitForTransaction state. The event `eTransReq` is colored in light blue because the state machine `Coordinator` is waiting for that one event to happen. Click `eWhileTransReq`, and the three other events will light up because the `Coordinator` machine is now waiting for one of the other three events to happen.
 
-This way, P users can interact with these P state machine visualizations too!
+This way, you can interact with these P state machine visualizations too!
 
 Stately's website contains four tabs:
 
-- **Code Tab**: Users use this tab to copy-and-paste code to visualize state machines.
+- **Code Tab**: Use this tab to copy-and-paste code to visualize state machines.
 - **State Tab**: This tab provides information on the state the user is currently at in the machine.
-- **Events Tab**: This tab logs all of the events that have occured so far among all machines.
-- **Actors Tab**: Users can switch between different machines' visualizations in this tab.
+- **Events Tab**: This tab logs all events that have occurred so far among all machines.
+- **Actors Tab**: Use this tab to switch to different P state machines in the visualization.
 
 <div align="center">
   <h2>State Machine Visualization Tool Tutorial</h2>

--- a/Docs/docs/index.md
+++ b/Docs/docs/index.md
@@ -15,17 +15,17 @@
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/p-org/peasy-ide-vscode/main/LICENSE)
 <a href="vscode:extension/PLanguage.p-extension">
-<button id="hover" style="font-weight:bold;" class="button1 block1"> Download the Peasy Extension! </button>
+<button id="hover" style="font-weight:bold;" class="button1 block1"> Download Peasy for VS Code </button>
 </a>
 
 **Peasy Overview:**
 
-Peasy is a VSCode Language Extension created by the P team to enable a richer, more intuitive user interface while developing P programs. It equips users with a familiar programming environment for developing, visualizing, and reviewing P code, expanding the true potential of P users.
+Peasy is a VS Code language extension created by the P team to enable a richer, more intuitive user interface while developing P programs. It equips users with a familiar programming environment for developing, visualizing, and reviewing P code, expanding the true potential of P users.
 
-Peasy achieves this by providing a VS code language extension for editing P programs and an intuitive interface for visualizing and reviewing the formal design and specification of a distributed system as a collection of P state machines.
+Peasy achieves this by providing a VS Code language extension for editing P programs and an intuitive interface for visualizing and reviewing the formal design and specification of a distributed system as a collection of P state machines.
 
 <div align="left">
-  <h2>Peasy Extension's Features</h2>
+  <h2>Peasy Features</h2>
 </div>
 
 **Syntax Highlighting**
@@ -47,12 +47,12 @@ Peasy achieves this by providing a VS code language extension for editing P prog
 [Learn more.](./features/error_tracing.md)
 
 <div align="left">
-  <h2>Peasy Extension's Shortcuts</h2>
+  <h2>Peasy Shortcuts</h2>
 </div>
 
-| Keypress | Description                                                                   |
-| -------- | ----------------------------------------------------------------------------- |
-| ++f4++   | Shows a dropdown menu of all the P projects in the current directory          |
-| ++f5++   | Compiles the Currently Selected P Project                                     |
-| ++f6++   | Opens the Peasy Trace Visualizer Webview                                      |
-| ++f7++   | Generates code to visualize the currently selected P project's state machines |
+| Keypress | Description                                                         |
+| -------- |---------------------------------------------------------------------|
+| ++f4++   | Shows a dropdown menu to select a P project                         |
+| ++f5++   | Compiles the current P Project                                      |
+| ++f6++   | Opens the Peasy Trace Visualizer Webview                            |
+| ++f7++   | Generates code to visualize state machines of the current P project |

--- a/Docs/docs/motivations.md
+++ b/Docs/docs/motivations.md
@@ -7,7 +7,7 @@
 </style>
 
 <div align="center">
-  <h2>The Motivation Behind the Peasy Extension</h2>
+  <h2>The Motivation Behind Peasy</h2>
 </div>
 
 Peasy brings the full power of an Intuitive Development Environment, including an editor, visualizer, checker, reviewer to P users.

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -47,14 +47,14 @@ nav:
     - Syntax Highlighting: ./features/syntax_highlighting.md
     - Compilation: 
       - Automatic Compilation:  ./features/compilation/basic.md
-      - Multiple Projects: ./features/compilation/multiple.md
       - Error Reporting: ./features/compilation/error_reporting.md
-    - Testing Framework: 
+      - Multiple Projects: ./features/compilation/multiple.md
+    - Testing Framework:
       - How to Run P Test Cases: ./features/testing.md
     - State Machine Visualizations: ./features/visualizations.md
     - Snippets: ./features/snippets.md
     - Trace Visualizer: ./features/error_tracing.md
-  - Contributing to the Peasy Extension: contribute.md
+  - Contributing to Peasy: contribute.md
   - The Motivation Behind Peasy: motivations.md
   
 markdown_extensions:
@@ -70,6 +70,10 @@ markdown_extensions:
   - attr_list 
   - md_in_html
   - pymdownx.keys
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
   - toc:
       toc_depth: 4


### PR DESCRIPTION
Updates include:
- Several minor updates and rephrasing
- Rephrase "the Peasy Extension" to just "Peasy"
- Removes talking about Multiple Projects in Basic P compilation page (there is a separate page for it)
- Reorders Compilation sub pages to put Multiple Projects page as last (since this is less common)
