### PR TITLE
Completely fixed flawed testing + changed testing framework video

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,16 +191,9 @@
     },
     "commands": [
       {
-        "command": "p.definition",
-        "title": "P: Go to Definition"
-      },
-      {
-        "command": "workbench.errors",
-        "title": "Error"
-      },
-      {
         "command": "workbench.files",
-        "title": "Files"
+        "title": "Peasy: Show Project Files", 
+        "description": "Users can select a P project to compile from a VSCode Quick Pick."
       },
       {
         "command": "peasy-visualizer.run",


### PR DESCRIPTION
1. I added a new testing framework video to show the option of changing the number of PChecker iterations. 
2. I completely fixed testing flaws; test cases now always check if p compile went through and if p check went through completely before outputting the result of a test case. 