### PR TITLE
commented out the replacing of event in fields with log text

### DIFF
--- a/media/js/shiviz/logEventMatcher/lemInterpreter.js
+++ b/media/js/shiviz/logEventMatcher/lemInterpreter.js
@@ -35,7 +35,7 @@ function LEMInterpreter(ast) {
  */
 LEMInterpreter.prototype.interpret = function (logEvent) {
   var env = logEvent.getFields();
-  env["event"] = logEvent.getText(); // TODO
+  // env["event"] = logEvent.getText(); // TODO
   var ret = this.ast.accept(this, env);
   return ret.val;
 };

--- a/media/js/shiviz/logEventMatcher/lemInterpreter.js
+++ b/media/js/shiviz/logEventMatcher/lemInterpreter.js
@@ -35,7 +35,6 @@ function LEMInterpreter(ast) {
  */
 LEMInterpreter.prototype.interpret = function (logEvent) {
   var env = logEvent.getFields();
-  // env["event"] = logEvent.getText(); // TODO
   var ret = this.ast.accept(this, env);
   return ret.val;
 };

--- a/media/js/shiviz/transform/collapseSequentialNodesTransformation.js
+++ b/media/js/shiviz/transform/collapseSequentialNodesTransformation.js
@@ -88,7 +88,6 @@ CollapseSequentialNodesTransformation.prototype.setThreshold = function (
  * @param {ModelNode} node The node whose LogEvents will be added as exemptions
  */
 CollapseSequentialNodesTransformation.prototype.addExemption = function (node) {
-  console.log("Adding exemption for node");
   var logEvents = node.getLogEvents();
   for (var i = 0; i < logEvents.length; i++) {
     this.exemptLogEvents[logEvents[i].getId()] = true;


### PR DESCRIPTION
#### Previous Issue

Doing `event=eWriteTransReq` in search bar fails to highlight nodes with the data `event=eWriteTransReq` because  ShiViz overwrites event data of a node with the actual log text. So `event=eWriteTransReq` was looking for log texts that equals "eWriteTransReq"

#### Solution

Commented this overwriting action out from previous ShiViz code.