### PR TITLE
Align titles and decrease video size in docs

### DIFF
--- a/Docs/docs/contribute.md
+++ b/Docs/docs/contribute.md
@@ -28,5 +28,6 @@ If you would like to contribute or add to the current state of the Peasy extensi
         * Windows: ++ctrl+shift+b++
 
 4.  In order to test out the extension, press ++f5++ to create an `Extension Development Host` where you can open P projects to view how the extension looks in its current state.
-
-![Extension Dev Host](images/extension_host.png)
+<div class="screenshots" markdown="1">
+  ![Extension Dev Host](images/extension_host.png)
+</div>

--- a/Docs/docs/css/extra.css
+++ b/Docs/docs/css/extra.css
@@ -58,4 +58,16 @@
   margin: 10px;
 }
 
+video {
+  width: 70%;
+}
+
+.screenshots { 
+  width: 70%;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+
 

--- a/Docs/docs/editingCode.md
+++ b/Docs/docs/editingCode.md
@@ -33,5 +33,9 @@ Syntax highlighting in P makes developing P programs easier, faster, and more en
 We created a Custom P theme that we suggest, but feel free to change the theme to whatever you like!
 
 Here is a sample of syntax highlighting for the [Two Phase Commit](https://github.com/p-org/P/tree/master/Tutorial/2_TwoPhaseCommit) protocol from the P tutorial. 
-![Syntax Highlighting](images/syntax_highlighting.png)
+
+
+<div class="screenshots" markdown="1">
+  ![Syntax Highlighting](images/syntax_highlighting.png)
+</div>
 

--- a/Docs/docs/index.md
+++ b/Docs/docs/index.md
@@ -45,3 +45,6 @@ Peasy achieves this by providing a VS Code language extension for editing P prog
 
 **Trace Visualizer**
 [Learn more.](trace-visualizer/getting_started.md)
+
+**State Machine Visualization**
+[Learn more.](visualizingStateMachines.md)

--- a/Docs/docs/runningTestcases.md
+++ b/Docs/docs/runningTestcases.md
@@ -18,7 +18,7 @@ The Testing Panel in VS Code lists all P test cases.
 In this panel, click the :material-play-outline: button to run test cases or jump to the corresponding test case in the P program by pressing the icon right next to :material-play-outline: button. 
 
 <figure class="video_container">
-  <video controls="true" allowfullscreen="true" >
+  <video controls="true" allowfullscreen="true" width="700">
     <source src="../videos/test_framework.mov" type="video/mp4">
   </video>
 </figure>

--- a/Docs/docs/trace-visualizer/feature_basics.md
+++ b/Docs/docs/trace-visualizer/feature_basics.md
@@ -6,7 +6,18 @@
 		content: attr(data-icon);
 		font-size: 1em;
 	}
+
+	.md-typeset h1,
+	.md-content__button {
+		display: none;
+	}
 </style>
+
+<div align="center">
+  <h2>Basics</h2>
+</div>
+
+**Compiling Code**
 
 1. Hovering over a log highlights the corresponding node in the main panel and vice versa.
 	

--- a/Docs/docs/trace-visualizer/feature_motifs.md
+++ b/Docs/docs/trace-visualizer/feature_motifs.md
@@ -6,7 +6,16 @@
 		content: attr(data-icon);
 		font-size: 1em;
 	}
+
+	.md-typeset h1,
+	.md-content__button {
+		display: none;
+	}
 </style>
+
+<div align="center">
+  <h2>Motifs</h2>
+</div>
 
 1. Pre-built options. Selecting one of the default motif options will highlights paths in the visualization that matches the motif pattren. In the example, paths in the main panel that matches Motif 1 (a simple sending request pattern, one machine sents to another machine) are highlighted.
 

--- a/Docs/docs/trace-visualizer/feature_search_bar.md
+++ b/Docs/docs/trace-visualizer/feature_search_bar.md
@@ -6,7 +6,16 @@
 		content: attr(data-icon);
 		font-size: 1em;
 	}
+
+	.md-typeset h1,
+	.md-content__button {
+		display: none;
+	}
 </style>
+
+<div align="center">
+  <h2>Search Bar</h2>
+</div>
 
 1. Fields filtering using "=". 
 

--- a/Docs/docs/trace-visualizer/getting_started.md
+++ b/Docs/docs/trace-visualizer/getting_started.md
@@ -18,7 +18,17 @@
 		content: attr(data-icon);
 		font-size: 1em;
 	}
+
+	.md-typeset h1,
+	.md-content__button {
+		display: none;
+	}
 </style>
+
+
+<div align="center">
+  <h2>Getting Started</h2>
+</div>
 
 ### **Launching**
 
@@ -41,8 +51,9 @@ Another alternative to launch the visualizer is to use the Visual Studio Code sh
 <u>Fields</u> - Each JSON log entry contains the log text, and fields associated with the log. I.e., field `action` is the type of log it is (`SendEvent`, `ReceiveEvent`, `StateTransition`, etc...). Field `target` is the target machine of a `SendEvent` log entry. Field `machine` is the name of the machine. More details can be found in [P JSON Output](./p_json_output.md)
 
 ### **Breakdown**
-
-![Trace Visualizer](../images/trace-visualizer/trace_visualizer.png)
+<div class="screenshots">
+	<img src="../../images/trace-visualizer/trace_visualizer.png">
+</div>
 
 <table>
 	<thead class="block">

--- a/Docs/docs/trace-visualizer/p_json_output.md
+++ b/Docs/docs/trace-visualizer/p_json_output.md
@@ -1,3 +1,14 @@
+<style>
+.md-typeset h1,
+	.md-content__button {
+		display: none;
+	}
+</style>
+
+<div align="center">
+  <h2>P JSON Output</h2>
+</div>
+
 ### **Basic Structure**
 
 Each P error trace JSON output is in the following format.

--- a/Docs/docs/visualizingStateMachines.md
+++ b/Docs/docs/visualizingStateMachines.md
@@ -15,12 +15,16 @@ Many P users wanted a method of creating visualizations of P state machines and 
 In order to create visualizations of P state machines, follow these steps or scroll down to watch a demo:
 
 1. Press ++f7++ to run the command `p compile --mode stately` in the terminal. Your visualization code is generated! A message in red should be sent through the terminal.
+<div class="screenshots" markdown="1">
    ![Syntax Highlighting](images/code_generation_text.png)
+</div>
 2. Navigate to the file using ++ctrl++ `Click` or ++cmd++ `Click`. Copy-and-paste the file contents into https://stately.ai/viz.
 3. Click the Visualize button on the bottom left!
 
 Voila! Here is an example visualization using the P Tutorial's Two Phase Commit project.
-![Visualization](images/visualization.png)
+<div class="screenshots" markdown="1">
+  ![Visualization](images/visualization.png)
+</div>
 
 <div align="center">
   <h2>How to Navigate Stately's Open Source Visualization Website</h2>


### PR DESCRIPTION
- Aligned the titles to the center in each page
- Added State Machine Visualization to features in the home page
- Decreased the size of videos and screenshots in each page