### PR TITLE
re-handled trace name for visualizer

### DIFF
--- a/media/js/shiviz/shiviz.js
+++ b/media/js/shiviz/shiviz.js
@@ -515,15 +515,24 @@ Shiviz.prototype.visualize = function (
     // Get the labels and its corresponding logEvents.
     const labels = [];
     const labelsLogEventsMap = {};
-    if (jsonLogs.length > 0 && Array.isArray(jsonLogs[0]))
-      for (let logIter = 0; logIter < jsonLogs.length; logIter++) {
-        const labelName = `Iteration #${logIter + 1}`;
-        labels.push(labelName);
-        labelsLogEventsMap[labelName] = getLogEvents(jsonLogs[logIter]);
+
+    // Iterate through all the traces
+    for (let t = 0; t < jsonLogs.length; t++) {
+      // Decompose and get traceName and trace itself
+      let { traceName, trace } = jsonLogs[t];
+      // Check if trace is verbose mode trace
+      if (trace.length > 0 && Array.isArray(trace[0])) {
+        // If it is, get each iter of the verbose trace
+        for (let vt = 0; vt < trace.length; vt ++) {
+          let labelName = `${traceName}_${vt}`;
+          labels.push(labelName);
+          labelsLogEventsMap[labelName] = getLogEvents(trace[vt]);
+        }
+        // If not, just push the trace itself
+      } else {
+        labels.push(traceName);
+        labelsLogEventsMap[traceName] = getLogEvents(trace);
       }
-    else {
-      labels.push("");
-      labelsLogEventsMap[""] = getLogEvents(jsonLogs);
     }
 
     labels.forEach(function (label) {

--- a/src/web/PeasyVizPanel.ts
+++ b/src/web/PeasyVizPanel.ts
@@ -218,12 +218,25 @@ export class PeasyVizPanel {
 
       // Read files selected and convert to actual JSON
       for (const file of files || []) {
+
+        // Get the trace filename
+        var traceName: string = file.path.split('/').pop() ?? "";
+        traceName = traceName.split('.')[0];
+
+        // Get the trace content
         const errorTraceJsonLogsUint8Array: Uint8Array =
           await vscode.workspace.fs.readFile(file);
-        const errorTrace: any[] = JSON.parse(
+        const trace: any[] = JSON.parse(
           new TextDecoder().decode(errorTraceJsonLogsUint8Array)
         );
-        errorTraces.push(errorTrace);
+
+        // Add the trace (include the traceName and trace itself)
+        errorTraces.push(
+          {
+            traceName,
+            trace,
+          }
+        );
       }
     }
 


### PR DESCRIPTION
\+ trace in visualizer should now reflect the actual trace name rather than "Iteration{n}"

I.e. Uploading `tcAbstractServerTrace.json` should say `tcAbstractServerTrace` in the visualizer.

![Screenshot 2023-08-29 at 10 42 39 AM](https://github.com/p-org/peasy-ide-vscode/assets/137958518/903e9b04-8b2d-49e2-8e20-33c149de0dc3)
