### PR TITLE
Unhighlight the newly processed edges for OnMonitorProcessEvents

### DIFF
--- a/media/js/shiviz/shiviz.js
+++ b/media/js/shiviz/shiviz.js
@@ -454,7 +454,7 @@ Shiviz.prototype.visualize = function (
         const logEntry = singleJsonLogIter[i];
 
         // Don't include StrategyDescription
-        if (logEntry.type === "StrategyDescription") {
+        if (["StrategyDescription", "Print"].includes(logEntry.type)) {
           continue;
           // Process AssertionFilure logEntry details before adding the AssertionFailure node to ShiViz graph.
         } else if (logEntry.type === "AssertionFailure") {

--- a/media/js/shiviz/visualization/visualEdge.js
+++ b/media/js/shiviz/visualization/visualEdge.js
@@ -59,6 +59,7 @@ function VisualEdge(sourceVisualNode, targetVisualNode) {
         .getFields().machine;
       var { machine: targetMachine, action: targetAction } =
         this.targetVisualNode.getNode().getFirstLogEvent().getFields();
+      // Unhighlight edge if edge is connected to a MonitorProcessEvent
       if (
         sourceMachine !== targetMachine &&
         targetAction === "MonitorProcessEvent"

--- a/media/js/shiviz/visualization/visualEdge.js
+++ b/media/js/shiviz/visualization/visualEdge.js
@@ -51,7 +51,22 @@ function VisualEdge(sourceVisualNode, targetVisualNode) {
     /** @private */
     this.opacity;
     this.setOpacity(0.6);
-    
+
+    try {
+      var sourceMachine = this.sourceVisualNode
+        .getNode()
+        .getFirstLogEvent()
+        .getFields().machine;
+      var { machine: targetMachine, action: targetAction } =
+        this.targetVisualNode.getNode().getFirstLogEvent().getFields();
+      if (
+        sourceMachine !== targetMachine &&
+        targetAction === "MonitorProcessEvent"
+      ) {
+        this.setOpacity(0);
+      }
+    } catch (e) {}
+
     this.$svg.attr({
         "x1": sourceVisualNode.getX(),
         "y1": sourceVisualNode.getY(),
@@ -174,7 +189,7 @@ VisualEdge.prototype.getOpacity = function() {
  * 
  * @param {Number} newOpacity The new opacity. Must be between 0 and 1 inclusive
  */
-VisualEdge.prototype.setOpacity = function(newOpacity) {
-    this.opacity = newOpacity;
-    this.$svg.attr("opacity", newOpacity);
+VisualEdge.prototype.setOpacity = function (newOpacity) {
+  this.opacity = newOpacity;
+  this.$svg.attr("opacity", newOpacity);
 };

--- a/src/web/PeasyVizPanel.ts
+++ b/src/web/PeasyVizPanel.ts
@@ -240,11 +240,6 @@ export class PeasyVizPanel {
       }
     }
 
-    // If just one error trace log, just make the errorTraces the one error trace selected
-    if (errorTraces.length === 1) {
-      errorTraces = errorTraces[0];
-    }
-
     // Read and convert the chosen file into string and render the visualizer html
     return shivizSourceHtml(
       shivizScriptsUriMap,


### PR DESCRIPTION
\+ Hide edges tying sent events to monitor process events
\+ Fixed a bug that caused crash when only selecting one json trace

#### Issue
Since the MonitorProcessEvent's vector clocks are now tied with the `senderMachine`'s vector clock, we need to hide the edge since it's now an actual send-receive event from machine to machines

#### Solution
Also, note that for now, print logs are discarded since it doesn't have a vector clock.

<img width="1746" alt="Screenshot 2023-08-30 at 5 15 01 PM" src="https://github.com/p-org/peasy-ide-vscode/assets/137958518/2e05983f-8321-4676-8d1a-a1cc8294a69e">
<img width="1746" alt="Screenshot 2023-08-30 at 5 14 25 PM" src="https://github.com/p-org/peasy-ide-vscode/assets/137958518/c72e3144-c031-4784-829c-b0e035afdf54">
