### PR TITLE
Add switching panel view section in docs

### DIFF
--- a/Docs/docs/editingCode.md
+++ b/Docs/docs/editingCode.md
@@ -10,6 +10,19 @@
   <h2>Editing Code</h2>
 </div>
 
+## **Syntax Highlighting**
+
+Syntax highlighting in P makes developing P programs easier, faster, and more enjoyable.
+
+We created a Custom P theme that we suggest, but feel free to change the theme to whatever you like!
+
+Here is a sample of syntax highlighting for the [Two Phase Commit](https://github.com/p-org/P/tree/master/Tutorial/2_TwoPhaseCommit) protocol from the P tutorial. 
+
+
+<div class="screenshots" markdown="1">
+  <img src="../images/syntax_highlighting.png" alt="Syntax Highlighting" >
+</div>
+
 ## **Snippet Auto-Completion**
 
 Coding in P is now much easier with snippets! Snippets allow P developers to complete templates of repeating code patterns in P, such as state machines, P statements, test cases, and more. Snippets appear through **Intellisense** when you type out the beginning of P keywords such as **machine** or **test** or **send**.
@@ -25,17 +38,3 @@ Snippets help P developers code faster and easier because they don't need to ref
         <source src="../videos/snippets.mov" type="video/mp4">
       </video>
     </figure>
-
-## **Syntax Highlighting**
-
-Syntax highlighting in P makes developing P programs easier, faster, and more enjoyable.
-
-We created a Custom P theme that we suggest, but feel free to change the theme to whatever you like!
-
-Here is a sample of syntax highlighting for the [Two Phase Commit](https://github.com/p-org/P/tree/master/Tutorial/2_TwoPhaseCommit) protocol from the P tutorial. 
-
-
-<div class="screenshots" markdown="1">
-  <img src="../images/syntax_highlighting.png" alt="Syntax Highlighting" >
-</div>
-

--- a/Docs/docs/installingPeasy.md
+++ b/Docs/docs/installingPeasy.md
@@ -14,10 +14,10 @@
 
 **Installing P**
 
-Follow the [Installing P](https://p-org.github.io/P/getstarted/install/) page to install P (version >= 2.0.15) based on the platform you are using. 
+Follow the [Installing P](https://p-org.github.io/P/getstarted/install/) page to install P (version >= 2.0.19) based on the platform you are using. 
 
 
-??? note "Make sure that you installed the right version of P (i.e., version >= 2.0.15)"
+??? note "Make sure that you installed the right version of P (i.e., version >= 2.0.19)"
     
     Run `p --version` command to get the version of P
 

--- a/Docs/docs/trace-visualizer/feature_basics.md
+++ b/Docs/docs/trace-visualizer/feature_basics.md
@@ -78,3 +78,14 @@ When you click on an individual node in the graph, a dialog box will open contai
 			<source src="https://github.com/p-org/peasy-ide-vscode/assets/137958518/13bfcbfa-6b57-49b4-87fa-929800b6b7a3" type="video/mp4"/>
 		</video>
 	</figure>
+
+**Switching Panel View**
+
+You can switch between different views to see all (logs and graph), logs, or graph panels when visualizing an individual trace. The drop-down menu on the left of the search bar enables you to switch between views.
+
+??? note "Demo Video: How to switch between views in trace visualizer?"	
+	<figure class="video_container">
+		<video controls="true" allowfullscreen="true" >
+			<source src="../../videos/trace-visualizer/panel_view_switching.mov" type="video/mp4"/>
+		</video>
+	</figure>

--- a/Docs/mkdocs.yml
+++ b/Docs/mkdocs.yml
@@ -49,7 +49,6 @@ nav:
     - Compiling Code: compilingCode.md
     - Running Testcases: runningTestcases.md
     - Editing Code: editingCode.md
-    - Keyboard Shortcuts and Commands: shortcutsAndCommands.md
     - Visualizing State Machines: visualizingStateMachines.md
     - Trace Visualizer:
       - Getting Started: trace-visualizer/getting_started.md
@@ -59,8 +58,8 @@ nav:
         - Motifs: trace-visualizer/feature_motifs.md
         - Compare and Contrast: trace-visualizer/feature_compare_contrast.md
       - P JSON Output: trace-visualizer/p_json_output.md
+    - Keyboard Shortcuts and Commands: shortcutsAndCommands.md
   - Contributing to the Peasy Extension: contribute.md
-  - The Motivation Behind Peasy: motivations.md
   
 markdown_extensions:
   - pymdownx.superfences

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Peasy Extension",
   "description": "Peasy Extension provides compilation support, a custom theme, syntax highlighting, a testing framework, error tracing visualization",
   "publisher": "PLanguage",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "icon": "Docs/docs/images/p-icon.png",
   "engines": {
     "vscode": "^1.78.0"


### PR DESCRIPTION
1. Update extension version to 0.0.6 for release
2. Add switching panel view section to visualizer docs 
3. Re-order syntax highlight and snippet part
4. Update P pre-requisite version in docs
5. Remove motivation section
6. Move Keyboard shortcuts and commands to the last section under User Guide