### PR TITLE
Fix testing framework ui to reflect run completion

### DIFF
--- a/src/ide/ui/compileCommands.ts
+++ b/src/ide/ui/compileCommands.ts
@@ -88,7 +88,7 @@ async function changeCompilationCommand(item: vscode.QuickPickItem) {
 // Runs p compile in the terminal.
 async function createCompileTask() {
   //Check if P is installed on computer
-  var p_installed = await checkPInstalled();
+  var p_installed = checkPInstalled();
   var type = PCommands.RunTask;
   if (!p_installed) {
     vscode.window.showErrorMessage(messages.Messages.Installation.noP);

--- a/src/miscTools.ts
+++ b/src/miscTools.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+var fs = require('fs');
 
 //Searches the current file directory for a specific pattern string and returns all files that match the pattern
 export async function searchDirectory(pattern: string) {
@@ -17,18 +18,12 @@ export async function searchDirectory(pattern: string) {
 }
 
 //Check if P is installed by searching in .dotnet/tools directory
-export async function checkPInstalled(): Promise<boolean> {
+export function checkPInstalled(): boolean {
   try {
     const homedir = require('os').homedir();
-    var filePath = homedir + "/.dotnet/tools";
-    
-    var uri: vscode.Uri = vscode.Uri.file(filePath);
-    var files: [string, vscode.FileType][] =
-      await vscode.workspace.fs.readDirectory(uri);
-    //turn arrays into JSON to check if the P executable exists inside of the file directory
-    var jsonFiles = JSON.stringify(files);
-    var jsonPFile = JSON.stringify(["p", vscode.FileType.File]);
-    if (jsonFiles.indexOf(jsonPFile) !== -1) {
+    var dirPath = homedir + "/.dotnet/tools";
+    var dirFiles = fs.readdirSync(dirPath);
+    if (dirFiles.includes("p")) {
       return true;
     }
   } catch (e) {


### PR DESCRIPTION
1. Fix the bug in testing framework to make the UI reflect a test case completion/cancellation status correctly
2. Add support to cancel in-flight test cases
3. Add support to show live logs of the p check test case execution in the output panel