### PR TITLE
Fix keybindings and testcases issue

### DIFF
--- a/Docs/docs/compilingCode.md
+++ b/Docs/docs/compilingCode.md
@@ -14,7 +14,7 @@
 
 Compiling P programs is now super easy with Peasy!
 
-Simply press ++f5++ or `Save` in VS Code editor and your project will be automatically compiled using the `p compile` command.
+Simply `Save` in VS Code editor and your project will be automatically compiled using the `p compile` command. Alternatively, you can press ++ctrl++ + ++b++ or ++f5++ to compile the current project.
 
 ??? note "Demo Video: How to compile code in Peasy?"
 
@@ -27,7 +27,7 @@ Simply press ++f5++ or `Save` in VS Code editor and your project will be automat
 ## **Error Reporting**
 
 Peasy reports compilation errors in the `Problems` panel.
-If compiling a P project with ++f5++ triggers errors, you can simply open the `Problems` panel in VS Code to view all compilation errors. You can jump to the error location by simply clicking the error.
+If compiling a P project with ++ctrl++ + ++b++ or ++f5++ triggers errors, you can simply open the `Problems` panel in VS Code to view all compilation errors. You can jump to the error location by simply clicking the error.
 
 ??? note "Demo Video: Where to view compilation errors in Peasy?"
 
@@ -43,7 +43,7 @@ When working in a directory with a single P project, Peasy automatically identif
 
 **But what if there are multiple P projects in the same directory?**
 
-To select another P project, press ++f4++. This will trigger a pop-up that shows all the available P projects in your current working directory. Simply click or select one of them to change the current P project!
+To select another P project, press ++ctrl++ + ++l++ or ++f4++. This will trigger a pop-up that shows all the available P projects in your current working directory. Simply click or select one of them to change the current P project!
 
 ??? note "Demo Video: How to compile multiple projects in Peasy?"
 

--- a/Docs/docs/installingPeasy.md
+++ b/Docs/docs/installingPeasy.md
@@ -68,7 +68,7 @@ There are many [tutorial projects](https://github.com/p-org/P/tree/master/Tutori
 
 **Compiling P Project**
 
-Press ++f5++ or `Save` in your VS Code editor and your project will automatically compile the current P project folder.
+Press ++ctrl++ + ++b++ or ++f5++ or simply `Save` in your VS Code editor and your project will automatically compile the current P project folder.
 
 Alternatively, you can compile your P project manually by running `p compile` in your terminal. Read [compiling a P program](https://p-org.github.io/P/getstarted/usingP/) page for more details.
 

--- a/Docs/docs/shortcutsAndCommands.md
+++ b/Docs/docs/shortcutsAndCommands.md
@@ -26,13 +26,13 @@
 
 **Keyboard Shortcuts**
 
-| Keypress         | Description                                                         |
-| ---------------- |---------------------------------------------------------------------|
-| ++f4++           | Shows a dropdown menu to select a P project                         |
-| ++f5++           | Compiles the current P Project                                      |
-| ++f6++           | Opens the Peasy Trace Visualizer Webview                            |
-| ++f7++           | Generates code to visualize state machines of the current P project |
-| ++ctrl++ + ++s++ | Saves and compiles the P project                                    |
+| Keypress                               | Description                                                         |
+| ---------------------------------------|---------------------------------------------------------------------|
+| <pre>++ctrl++ + ++l++ / ++f4++</pre>   | Shows a dropdown menu to select a P project                         |
+| <pre>++ctrl++ + ++b++ / ++f5++</pre>   | Compiles the current P Project                                      |
+| ++f6++                                 | Opens the Peasy Trace Visualizer Webview                            |
+| ++f7++                                 | Generates code to visualize state machines of the current P project |
+| ++ctrl++ + ++s++                       | Saves and compiles the P project                                    |
 
 **VS Code Commands**
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Peasy Extension",
   "description": "Peasy Extension provides compilation support, a custom theme, syntax highlighting, a testing framework, error tracing visualization",
   "publisher": "PLanguage",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "icon": "Docs/docs/images/p-icon.png",
   "engines": {
     "vscode": "^1.78.0"
@@ -115,7 +115,23 @@
       {
         "key": "f5",
         "command": "runCommands",
-        "when": "editorLangId == p",
+        "when": "editorLangId == p || resourceLangId == p || resourceExtname == .p",
+        "args": {
+          "commands": [
+            {
+              "command": "workbench.action.tasks.terminate",
+                "args": "terminateAll"
+            },
+            {
+              "command": "workbench.action.tasks.runTask",
+              "args": "p-vscode: Compile"
+            }
+          ]
+        }
+      },
+      {
+        "key": "ctrl+b",
+        "command": "runCommands",
         "args": {
           "commands": [
             {
@@ -132,7 +148,23 @@
       {
         "key": "f4",
         "command": "runCommands",
-        "when": "editorLangId == p",
+        "when": "editorLangId == p || resourceLangId == p || resourceExtname == .p",
+        "args": {
+          "commands": [
+            {
+              "command": "workbench.action.tasks.terminate",
+                "args": "terminateAll"
+            },
+            {
+              "command": "workbench.files"
+            }
+          ]
+        }
+      },
+      {
+        "key": "ctrl+l",
+        "command": "runCommands",
+        "when": "!terminalFocus",
         "args": {
           "commands": [
             {
@@ -150,12 +182,12 @@
         "command": "peasy-visualizer.run", 
         "key": "f6", 
         "mac": "f6",
-        "when": "editorLangId == p"
+        "when": "!inDebugMode"
       }, 
       {
         "command": "runCommands", 
         "key": "f7",
-        "when": "editorLangId == p",
+        "when": "editorLangId == p || resourceLangId == p || resourceExtname == .p",
         "args": {
           "commands": [
             {

--- a/src/ide/ui/testinginEditor.ts
+++ b/src/ide/ui/testinginEditor.ts
@@ -45,7 +45,7 @@ export default class TestingEditor {
     );
 
     //Looks through the entire test folder to discover where is the test file and where the tests are.
-    var files = await searchDirectory(path.join("**", "PTst", "**", "*.p"));
+    var files = await searchDirectory(path.join("**", "*.p"));
     if (files != null) {
       for (var i = 0; i < files.length; i++) {
         var x = files.at(i);
@@ -67,7 +67,7 @@ export default class TestingEditor {
       const folder = vscode.workspace.workspaceFolders[0].uri;
             currProject = currProject.replace(folder.fsPath, "**");
       // Create relative path pattern to the workspace
-      var files = await searchDirectory(path.join(currProject, "PTst", "**", "*.p"));
+      var files = await searchDirectory(path.join(currProject, "**", "*.p"));
 
       // Create test items for selected p project in the testing panel
       if (files != null) {
@@ -319,18 +319,6 @@ function updateNodeFromDocument(e: vscode.TextDocument) {
 
   const filename = path.parse(e.fileName).base;
   if (filename == undefined) {
-    return;
-  }
-  var dirname = path.parse(e.fileName).dir;
-  var isTestDir = false;
-  while (dirname != "") {
-    if (dirname.endsWith("PTst")) {
-      isTestDir = true;
-      break;
-    }
-    dirname = path.parse(dirname).dir;
-  }
-  if (!isTestDir) {
     return;
   }
   if (e.uri.scheme !== "file") {


### PR DESCRIPTION
Issue:
1. Key bindings are activated only when the cursor focus is in a p file
2. Testcases are not detected when the PTst folder has testcase files in nested folders

This PR does the following:
1. Detects testcases from PTst folder no matter where they are in the VSCode workspace
2. F4 and F5 keys will run their corresponding peasy tasks when cursor focus is in a p file or if the selected file is a p file
3. Added additional keybindings that don't interfere with VSCode debug shortcuts:

- "Ctrl + b" or "F5" - build project
- "Ctrl + l" or "F4" - list projects