### PR TITLE
Add vscode additionalArgs option in settings

### DIFF
--- a/Docs/docs/runningTestcases.md
+++ b/Docs/docs/runningTestcases.md
@@ -44,3 +44,20 @@ Peasy lets you configure the number of schedules to explore for test cases. Simp
       "p-vscode.schedules": 2000
     }
     ```
+
+Peasy lets you configure other commandline options as well for test cases. Simply add the ***"p-vscode.additionalArgs"*** key and specify your preferred commandline arguments in the VS Code `settings.json` file. Run the testcases from the testing panel, and the extension will automatically check each test case with the provided commandline arguments.
+
+```
+{
+  "p-vscode.additionalArgs": "<additional_commandline_args>"
+}
+```
+
+??? note "Example: Customizing commandline arguments for test cases"
+  
+    For example, when you add the below key-value pair to your VS Code settings.json file, each test case will be checked in bug finding mode with 100 max steps.
+    ```
+    {
+      "p-vscode.additionalArgs": "--mode bugfinding --max-steps 100"
+    }
+    ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Peasy Extension",
   "description": "Peasy Extension provides compilation support, a custom theme, syntax highlighting, a testing framework, error tracing visualization",
   "publisher": "PLanguage",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "icon": "Docs/docs/images/p-icon.png",
   "engines": {
     "vscode": "^1.78.0"
@@ -222,6 +222,12 @@
           "type": "integer",
           "default": 1000,
           "description": "Manages the number of schedules run during P testing at a 'p check' command."
+        },
+        "p-vscode.additionalArgs": {
+          "scope": "window",
+          "type": "string",
+          "default": "",
+          "description": "Manages the commandline arguments during P testing at a 'p check' command."
         },
         "p-vscode.pcompile.exclude": {
           "scope": "window",

--- a/src/ide/ui/testinginEditor.ts
+++ b/src/ide/ui/testinginEditor.ts
@@ -14,7 +14,7 @@ export default class TestingEditor {
     "P Tests"
   );
   static testRe = /^\s*test\s/g;
-
+ 
   public static async createAndRegister(
     context: vscode.ExtensionContext
   ): Promise<TestingEditor> {
@@ -243,8 +243,10 @@ function runCheckCommand(
 ) {
   //number of p checker schedules that are run
 
-  const numSchedules: String =
+  const numSchedules: string =
     vscode.workspace.getConfiguration("p-vscode").get("schedules") ?? "1000";
+  var additionalArgs: string =
+    vscode.workspace.getConfiguration("p-vscode").get("additionalArgs") ?? "";
   //The p check command depends on if the terminal is bash or zsh.
   var command;
   if (!checkPInstalled()) {
@@ -252,7 +254,17 @@ function runCheckCommand(
     run.end();
     return;
   } else {
-    command = "p check -tc " + tc.label + " -s " +numSchedules;
+    command = "p check -tc " + tc.label;
+    if (additionalArgs != "") {
+      // Remove the test case argument from the additionalargs param if exists
+      additionalArgs = additionalArgs.replace(/(^| )(-tc|--test-case) (\w+)/, "");
+      command += " " + additionalArgs;
+    }
+
+    // If user provides schedule option in both schedules and additionalArgs, consider the value provided in the additionalArgs param
+    if (!/(^| )(-s|--schedules) (\w+)/.test(additionalArgs)) {
+      command += " -s " + numSchedules; 
+    }
   }
 
   // Prints in the output channel


### PR DESCRIPTION
1. Add support for additionalArgs param in vs code settings.json to allow user to pass custom commandline arguments with the test cases
2. Update the documentation on how to use additionalArgs in vs code
3. Update peasy version for new release