### PR TITLE
check for P by trying to run it

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Peasy Extension",
   "description": "Peasy Extension provides compilation support, a custom theme, syntax highlighting, a testing framework, error tracing visualization",
   "publisher": "PLanguage",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "icon": "Docs/docs/images/p-icon.png",
   "engines": {
     "vscode": "^1.78.0"

--- a/src/ide/ui/compileCommands.ts
+++ b/src/ide/ui/compileCommands.ts
@@ -88,7 +88,7 @@ async function changeCompilationCommand(item: vscode.QuickPickItem) {
 // Runs p compile in the terminal.
 async function createCompileTask() {
   //Check if P is installed on computer
-  var p_installed = checkPInstalled();
+  const p_installed = await checkPInstalled();
   var type = PCommands.RunTask;
   if (!p_installed) {
     vscode.window.showErrorMessage(messages.Messages.Installation.noP);

--- a/src/ide/ui/testinginEditor.ts
+++ b/src/ide/ui/testinginEditor.ts
@@ -233,7 +233,7 @@ function checkResult(
 }
 
 //Runs p check in a child process and returns the stdout or result.
-function runCheckCommand(
+async function runCheckCommand(
   run: vscode.TestRun,
   tc: vscode.TestItem,
   tcOutput: vscode.OutputChannel,
@@ -249,7 +249,8 @@ function runCheckCommand(
     vscode.workspace.getConfiguration("p-vscode").get("additionalArgs") ?? "";
   //The p check command depends on if the terminal is bash or zsh.
   var command;
-  if (!checkPInstalled()) {
+  const p_installed = await checkPInstalled();
+  if (!p_installed) {
     tcOutput.appendLine(messages.Messages.Installation.noP);
     run.end();
     return;

--- a/src/miscTools.ts
+++ b/src/miscTools.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 var fs = require('fs');
 const path = require('path'); 
-
+const { exec } = require('child_process');
+const util = require('util');
 
 //Searches the current file directory for a specific pattern string and returns all files that match the pattern
 export async function searchDirectory(pattern: string) {
@@ -20,22 +21,13 @@ export async function searchDirectory(pattern: string) {
   return files;
 }
 
-//Check if P is installed by searching in .dotnet/tools directory
-export function checkPInstalled(): boolean {
+//Check if P is installed by trying to run it
+export async function checkPInstalled(): boolean {
+  const execPromise = util.promisify(exec);
   try {
-    const homedir = require('os').homedir();
-    var dirPath = path.join(homedir, ".dotnet", "tools");
-    var dirFiles = fs.readdirSync(dirPath);
-    var isPFileFound = false;
-    dirFiles.forEach((file: string) => { 
-      if (path.parse(file).name == "p") {
-        isPFileFound = true;
-      }
-    });
-    return isPFileFound;
-  } catch (e) {
-    console.log(e);
+    await execPromise(`p --version`);
+  } catch(error) {
+    return false;
   }
-
-  return false;
+  return true;
 }

--- a/src/miscTools.ts
+++ b/src/miscTools.ts
@@ -22,7 +22,7 @@ export async function searchDirectory(pattern: string) {
 }
 
 //Check if P is installed by trying to run it
-export async function checkPInstalled(): boolean {
+export async function checkPInstalled(): Promise<boolean> {
   const execPromise = util.promisify(exec);
   try {
     await execPromise(`p --version`);


### PR DESCRIPTION
The current behavior of the function `checkPInstalled` hardcodes the path to look for P. However it is possible that P is installed and is not in this specific path. For instance:
- Users may have changed the [DOTNET_CLI_HOME](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_cli_home) environment variable
- Users may have P installed via [nix](https://nixos.org) or some other development environment manager

This has already caused issues in the past with issues like #75

Instead of trying to find where P is installed this pr simply tries to run P. If the command `p --version` manages to run without throwing an error it is assumed that P is installed on the system.


I have only tested this on a linux box, other systems probably work but I do not know for sure.