### PR TITLE
Add config option `p-vscode.compileOnSave`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peasy-extension",
-  "version": "1.0.2",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peasy-extension",
-      "version": "1.0.2",
+      "version": "1.0.6",
       "dependencies": {
         "cross-fetch": "^3.1.6",
         "extract-zip": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -229,6 +229,12 @@
           "default": "",
           "description": "Manages the commandline arguments during P testing at a 'p check' command."
         },
+        "p-vscode.compileOnSave": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Run the 'Compile' task on save."
+        },
         "p-vscode.pcompile.exclude": {
           "scope": "window",
           "type": "array",

--- a/src/ide/ui/compileCommands.ts
+++ b/src/ide/ui/compileCommands.ts
@@ -36,7 +36,8 @@ export default class CompileCommands {
       vscode.workspace.onDidCreateFiles((e) => generateProjects()),
       // Trigger the compile task on saving P files only
       vscode.workspace.onDidSaveTextDocument(async (e) => {
-        if(e.fileName.endsWith(".p")){
+        const enabled: boolean = vscode.workspace.getConfiguration("p-vscode").get("compileOnSave")!;
+        if (enabled && e.fileName.endsWith(".p")) {
           for (var t of await vscode.tasks.fetchTasks()) {
             if (t.name === "Compile") {
               vscode.tasks.executeTask(t);


### PR DESCRIPTION
Some users (such as myself) routinely save incomplete code. Running
a new task on each save event creates a lot of noise in such cases.
Even if there is an objection to this way of using a text editor, the
reality of muscle memory cannot be denied.

Whether this default behavior should be disabled is out of scope for
this change and merits an open discussion involving maintainers and users.