### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Peasy extension are documented in this file.
 
-## [Unreleased]
+## [1.1.0] - 2026-05-24
 
 ### Fixed
 - **Critical:** Removed hardcoded developer-machine path
@@ -35,6 +35,11 @@ All notable changes to the Peasy extension are documented in this file.
   `p-vscode.languageServer.cliPath`, `p-vscode.languageServer.launchArgs`.
 - `peasy.compile` command (palette-accessible) that invokes the active
   compile task.
+- `peasy.showProjectFiles` command (replaces the reserved-namespace
+  `workbench.files` command ID).
+- `@vscode/vsce` pinned as a devDependency with a `package:vsix` script for
+  reproducible, offline-friendly packaging; CI/publish use
+  `npx --no-install vsce`.
 - `.eslintrc.json` with a `@typescript-eslint/recommended` baseline.
 - `extensionKind`, `capabilities.virtualWorkspaces`, and
   `capabilities.untrustedWorkspaces` declarations in `package.json`.
@@ -61,6 +66,6 @@ All notable changes to the Peasy extension are documented in this file.
 - Dead `which-module` dependency.
 - Unused `runTest.js` reference in scripts (no test runner shipped yet).
 
-## 1.0.6 and earlier
+## 1.0.5 and earlier
 
-See git history.
+See git history and the [GitHub releases](https://github.com/p-org/peasy-ide-vscode/releases).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peasy-extension",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peasy-extension",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Peasy Extension",
   "description": "Peasy Extension provides compilation support, a custom theme, syntax highlighting, a testing framework, error tracing visualization",
   "publisher": "PLanguage",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "icon": "resources/p-icon.png",
   "license": "MIT",
   "homepage": "https://p-org.github.io/peasy-ide-vscode/",


### PR DESCRIPTION
## Summary

Release-prep for **1.1.0** — the first release carrying the cross-IDE / cross-platform work merged in #90 and the `vsce`-pinning follow-up in #91.

- Bumps `version` `1.0.6` → `1.1.0` in `package.json` (+ `package-lock.json`).
- Finalizes `CHANGELOG.md`: `[Unreleased]` → `[1.1.0] - 2026-05-24`, and adds the `peasy.showProjectFiles` rename and `@vscode/vsce` pinning entries that landed after the changelog was first written.

The last published GitHub Release is `1.0.5`, so none of the #90/#91 work has shipped to the marketplace yet; `1.1.0` covers it all.

## Release steps (after this merges)

1. Merge this PR to `main`.
2. **Create a GitHub Release** tagged `1.1.0` (Releases → Draft a new release → tag `1.1.0`, target `main`). Publishing the release triggers `publish-extension.yml`.
3. The workflow builds, packages with the pinned `vsce`, and publishes to the **VS Marketplace** (and **Open VSX** if `OVSX_PAT` is set).

## ⚠️ Prerequisites / caveats

- **Secrets must be valid.** The publish needs `VSCE_PAT` (Azure DevOps token, Marketplace → Manage scope, for the `PLanguage` publisher) and, for Cursor/VSCodium users, `OVSX_PAT`. Validity can't be verified ahead of time — if a token is missing/expired the corresponding publish step fails with a `401`. You can pre-check with `npx vsce verify-pat PLanguage -p <token>`.
- This PR itself publishes nothing; it only prepares the version/changelog. The actual marketplace publish happens when the GitHub Release is created.

## Test plan

- [x] `npm install` → lockfile reports `1.1.0`
- [x] `npm run typecheck` clean
- [x] `npm run package:vsix` produces the `.vsix` at 1.1.0 (515 KB)
- [ ] CI green on all three OSes
- [ ] After release: confirm `publish-extension.yml` succeeds for both registries


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmvQ5g2HE6cTHmmRrJ6SaP)_